### PR TITLE
Add rmcp stdio server example

### DIFF
--- a/mcp-command/src/main.rs
+++ b/mcp-command/src/main.rs
@@ -1,5 +1,5 @@
 use cmd_lib::run;
-use mcp_lib::Mcp;
+use mcp_lib::{Mcp, start_hello_server};
 
 fn main() {
     let output = match run("echo", &["Hello from mcp-command"]) {
@@ -12,4 +12,8 @@ fn main() {
 
     let formatted = Mcp::process_output(&output.stdout);
     println!("{formatted}");
+
+    if let Err(err) = start_hello_server() {
+        eprintln!("server error: {err}");
+    }
 }

--- a/mcp-lib/Cargo.toml
+++ b/mcp-lib/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+rmcp = { version = "0.1", features = ["server"] }

--- a/mcp-lib/src/lib.rs
+++ b/mcp-lib/src/lib.rs
@@ -8,6 +8,23 @@ impl Mcp {
     }
 }
 
+/// Start a simple "Hello World" MCP server over stdio.
+///
+/// This uses the `rmcp` crate's stdio server functionality.
+pub fn start_hello_server() -> std::io::Result<()> {
+    use rmcp::stdio::Server;
+
+    let mut server = Server::new();
+    println!("MCP stdio server ready");
+
+    for mut connection in server.incoming() {
+        let mut stream = connection?;
+        stream.send(b"Hello World\n")?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
- refactor `start_hello_server` to use an stdio rmcp server
- launch the hello world server without specifying an address

## Testing
- `cargo fmt --all` *(failed: `cargo-fmt` not installed)*
- `cargo clippy` *(failed: `cargo-clippy` not installed)*
- `cargo test --workspace` *(failed to fetch `rmcp` crate)*